### PR TITLE
allow node-repl resizing

### DIFF
--- a/lib/node-repl-view.js
+++ b/lib/node-repl-view.js
@@ -1,41 +1,68 @@
 'use babel';
 
 import repl from 'repl';
-import vm from 'vm';
 import NodeReplReadStream from './node-repl-read-stream';
 import NodeReplWriteStream from './node-repl-write-stream';
 
 const WELCOME_MESSAGE = 'Welcome to Node.js ' + process.version;
 
 export default class NodeReplView {
-
-  constructor(serializedState) {
+  constructor() {
     // Create root element
-    this.element = document.createElement('div');
-    this.element.classList.add('node-repl');
-    this.element.classList.add('native-key-bindings');
-    this.element.setAttribute('tabindex', -1);
+    this.outStream;
+    this.outputElement;
+    this.element = atom.views.addViewProvider(() => {
+      const element = document.createElement('main');
 
-    this.outputElement = document.createElement('div');
-    this.outputElement.textContent = WELCOME_MESSAGE;
+      element.classList.add('node-repl', 'native-key-bindings');
+      element.setAttribute('tabindex', -1);
 
-    this.element.appendChild(this.outputElement);
-    this.outStream = new NodeReplWriteStream(this.outputElement);
+      const resizeElement = document.createElement('div');
+      resizeElement.classList.add('node-repl__resizer');
+      resizeElement.addEventListener('mousedown', resizeStart);
+
+      function resizeStart() {
+        document.addEventListener('mousemove', resize);
+        document.addEventListener('mouseup', resizeStop);
+      }
+
+      function resize(evt) {
+        const width = element.offsetWidth + element.getBoundingClientRect().left - evt.pageX;
+
+        element.style.width = width + 'px';
+      }
+
+      function resizeStop() {
+        document.removeEventListener('mousemove', resize);
+        document.removeEventListener('mouseup', resizeStop);
+      }
+
+      const outputElement = document.createElement('section');
+      outputElement.classList.add('node-repl__output');
+      outputElement.innerHTML = WELCOME_MESSAGE;
+
+      this.outputElement = outputElement;
+
+      element.appendChild(resizeElement);
+      element.appendChild(this.outputElement);
+
+      this.outStream = new NodeReplWriteStream(this.outputElement);
+
+      return element;
+    });
   }
 
   run() {
     const textEditor = atom.workspace.getActiveTextEditor();
     const readStream = new NodeReplReadStream(textEditor.getText());
-    this.appendRunMessage("Executing " + readStream.getLines() + " lines...");
+    this.appendRunMessage('Executing ' + readStream.getLines() + ' lines...');
     this.replServer = repl.start({
       input: readStream,
       output: this.outStream,
       ignoreUndefined: true,
-      prompt: "",
+      prompt: '',
       terminal: false
     });
-
-    console.log(this.replServer.context.console);
   }
 
   appendRunMessage(message) {
@@ -59,5 +86,4 @@ export default class NodeReplView {
   getElement() {
     return this.element;
   }
-
 }

--- a/styles/node-repl.less
+++ b/styles/node-repl.less
@@ -5,13 +5,25 @@
 @import "ui-variables";
 
 .node-repl {
+  position: relative;
   padding: @tab-height 30px;
   width: 500px;
   font-size: @input-font-size;
+  overflow: scroll;
+
   p {
     margin-left: 5px;
+    white-space: pre;
   }
-  .run-header {
-    font-weight: bold;
+  .run-header { font-weight: bold; }
+
+  &__resizer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 10px;
+    height: 100%;
+
+    &:hover { cursor: col-resize; }
   }
 }


### PR DESCRIPTION
This pull request enables resizing similar to `atom/tree-view`

It also:
- updates stylesheet to allow for overflow on the `repl view`
- uses the `addViewProvider` per the [atom documentation](//atom.io/docs/api/v1.15.0/Workspace#instance-addRightPanel)