### PR TITLE
allow for local modules when available

### DIFF
--- a/lib/node-repl-view.js
+++ b/lib/node-repl-view.js
@@ -1,7 +1,8 @@
 'use babel';
 
 import repl from 'repl';
-import vm from 'vm';
+import { dirname } from 'path';
+import { readdirSync } from 'fs';
 import NodeReplReadStream from './node-repl-read-stream';
 import NodeReplWriteStream from './node-repl-write-stream';
 
@@ -26,16 +27,28 @@ export default class NodeReplView {
   run() {
     const textEditor = atom.workspace.getActiveTextEditor();
     const readStream = new NodeReplReadStream(textEditor.getText());
-    this.appendRunMessage("Executing " + readStream.getLines() + " lines...");
+    const filePath = textEditor.getPath();
+    const dirPath = filePath ? `${dirname(filePath)}/node_modules` : null;
+
+    this.appendRunMessage('Executing ' + readStream.getLines() + ' lines...');
     this.replServer = repl.start({
       input: readStream,
       output: this.outStream,
       ignoreUndefined: true,
-      prompt: "",
+      prompt: '',
       terminal: false
     });
 
-    console.log(this.replServer.context.console);
+    if (dirPath) {
+      try {
+        readdirSync(dirPath);
+        this.replServer.context.module.paths.unshift(dirPath);
+      }
+      catch (err) {
+        console.warn('err:', err);
+      }
+
+    }
   }
 
   appendRunMessage(message) {

--- a/lib/node-repl-view.js
+++ b/lib/node-repl-view.js
@@ -58,7 +58,8 @@ export default class NodeReplView {
     const textEditor = atom.workspace.getActiveTextEditor();
     const readStream = new NodeReplReadStream(textEditor.getText());
     const filePath = textEditor.getPath();
-    const dirPath = filePath ? `${dirname(filePath)}/node_modules` : null;
+    const dirPath = filePath ? dirname(filePath) : null;
+    const nodeModulesPath = dirPath ? `${dirPath}/node_modules` : null;
 
     this.appendRunMessage('Executing ' + readStream.getLines() + ' lines...');
     this.replServer = repl.start({
@@ -72,10 +73,12 @@ export default class NodeReplView {
     if (dirPath) {
       try {
         readdirSync(dirPath);
-        this.replServer.context.module.paths.unshift(dirPath);
+        this.replServer.context.module.filename = filePath;
+        this.replServer.context.module.paths.unshift(nodeModulesPath);
       }
       catch (err) {
-        console.warn('err:', err);
+        console.warn(`node-repl is unable to to read the file's (${filePath}) directory tree`);
+        console.error('node-repl error:', err);
       }
 
     }


### PR DESCRIPTION
This pull request allows for local `node_modules` by pushing the file's path to the repl context if that path has a `node_modules` directory.